### PR TITLE
Don't clone the workflows folder until AFTER project makes artifacts

### DIFF
--- a/.github/workflows/make-release-artifacts.yml
+++ b/.github/workflows/make-release-artifacts.yml
@@ -30,13 +30,6 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
 
-      - name: Checkout .github repo
-        uses: actions/checkout@master
-        with:
-          repository: rokucommunity/workflows
-          path: nested-ci
-          ref: ${{ inputs.workflows-ref }}
-
       - name: Setup node
         uses: actions/setup-node@master
         with:
@@ -46,7 +39,14 @@ jobs:
         run: npm ci
 
       - name: Run package
-        run: npm run package;
+        run: npm run package
+
+      - name: Checkout the rokucommunity/workflows repo
+        uses: actions/checkout@master
+        with:
+          repository: rokucommunity/workflows
+          path: nested-ci
+          ref: ${{ inputs.workflows-ref }}
 
       - name: Setup node
         uses: actions/setup-node@master


### PR DESCRIPTION
This was accidentally causing some projects to include the nested_ci folder in their npm packages. We don't need to clone that repo until _after_ the artifacts are created, so this PR just defers that until afterwords.