### PR TITLE
Get the release version from the branch name passed into the function

### DIFF
--- a/src/ReleaseCreator.ts
+++ b/src/ReleaseCreator.ts
@@ -494,9 +494,9 @@ export class ReleaseCreator {
 
         const project = await ProjectManager.initialize({ ...options, installDependencies: false });
 
-        logger.log(`Checkout the release ${options.ref}`);
-        utils.executeCommand(`git checkout --quiet ${options.ref}`, { cwd: project.dir });
-        const releaseVersion = await this.getVersion(project.dir);
+        logger.log(`Get the release version from the ref ${options.ref}`);
+        const match = /^release\/(\d+\.\d+\.\d+)$/.exec(options.ref);
+        const releaseVersion = match?.[1];
 
         logger.log(`Find the existing draft release`);
         const releases = await this.listGitHubReleases(options.projectName);


### PR DESCRIPTION
I ran this change manually for the `close-release` that failed here: https://github.com/rokucommunity/promises/actions/runs/15543443927/job/43759451328